### PR TITLE
Update verison of PG to 6.1.2 - the old version was failing with SSL …

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Jive Software <jivedev@jivesoftware>",
   "dependencies": {
     "q": "0.9.3",
-    "pg": "4.3.0",
+    "pg": "6.1.2",
     "sql-ddl-sync": "git://github.com/jivesoftware/node-sql-ddl-sync.git",
     "jive-sdk": "*",
     "flat": "1.2.1",


### PR DESCRIPTION
I'm using jive-persistence-postgres with AWS Beanstalk Node app server to an AWS RDS Postgres DB server that has SSL enabled.  It was getting an error logging into Postgres using the 4.3 PG module.   I switched that to the PG version 6.1.2 module and it worked successfully.